### PR TITLE
Add Transformers Auto* support for video‑SALMONN 2+

### DIFF
--- a/video_SALMONN2_plus/README.md
+++ b/video_SALMONN2_plus/README.md
@@ -67,6 +67,8 @@ generated_ids = model.generate(**inputs, max_new_tokens=128)
 print(processor.batch_decode(generated_ids, skip_special_tokens=True)[0])
 ```
 
+Note: audio is interleaved into video tokens only when you use `<video>` without an explicit `<audio>`/`<|audio_pad|>` placeholder.
+
 If you want to use the Auto* classes without `trust_remote_code`, you can register locally:
 
 ```python

--- a/video_SALMONN2_plus/README.md
+++ b/video_SALMONN2_plus/README.md
@@ -39,3 +39,37 @@ video-SALMONN 2+ is built on Qwen 2.5-VL using a similar pipeline of video-SALMO
    ```bash
    bash scripts/test_8.sh --interval 0.1 --run_name eval --dataset path_to_dataset --max_frames 768 --max_pixels 61250 --model path_to_audio_model --model_base path_to_audio_model --lora_ckpt model_ckpt
    ```
+
+## Transformers Auto* Usage
+
+The model now exposes standard Transformers entry points so you can load it with `AutoModelForCausalLM` and
+`AutoProcessor` (image/video/audio). Use `trust_remote_code=True` when loading from a repo that contains this code.
+
+```python
+from transformers import AutoModelForCausalLM, AutoProcessor
+
+model = AutoModelForCausalLM.from_pretrained(
+    "path_or_hub_repo",
+    trust_remote_code=True,
+    torch_dtype="auto",
+    device_map="auto",
+)
+processor = AutoProcessor.from_pretrained("path_or_hub_repo", trust_remote_code=True)
+
+inputs = processor(
+    text="Describe this video and its audio: <video>",
+    videos=video_frames,  # numpy/torch array or list of frames
+    audio=audio_waveform,  # raw waveform array
+    return_tensors="pt",
+)
+
+generated_ids = model.generate(**inputs, max_new_tokens=128)
+print(processor.batch_decode(generated_ids, skip_special_tokens=True)[0])
+```
+
+If you want to use the Auto* classes without `trust_remote_code`, you can register locally:
+
+```python
+from qwenvl.model import register_transformers
+register_transformers()
+```

--- a/video_SALMONN2_plus/README_transformers.md
+++ b/video_SALMONN2_plus/README_transformers.md
@@ -1,0 +1,97 @@
+# video-SALMONN 2+ — Transformers-Compatible Usage
+
+This folder adds a Transformers-friendly entry point for the video-SALMONN 2+ model so you can use
+`AutoModelForCausalLM`, `AutoProcessor`, Trainer, and `generate()` without custom scripts.
+
+## What’s Included
+
+- **Config**: `Qwen2_5_VLConfig` now carries multimodal token ids/strings and `auto_map` for Auto* loading.
+- **Model Alias**: `VideoSALMONN2PlusForConditionalGeneration` (alias of `video_SALMONN2_plus`) for standard naming.
+- **Processor**: `VideoSALMONN2PlusProcessor` handles image/video/audio inputs and expands placeholders.
+- **Optional Registration**: `register_transformers()` registers AutoConfig/AutoModel/AutoProcessor locally.
+
+## Load with Auto* (recommended)
+
+This requires `trust_remote_code=True` when loading from a repo containing this code.
+
+```python
+from transformers import AutoModelForCausalLM, AutoProcessor
+
+model = AutoModelForCausalLM.from_pretrained(
+    "path_or_hub_repo",
+    trust_remote_code=True,
+    torch_dtype="auto",
+    device_map="auto",
+)
+processor = AutoProcessor.from_pretrained("path_or_hub_repo", trust_remote_code=True)
+```
+
+## Local Auto* Registration (no trust_remote_code)
+
+```python
+from qwenvl.model import register_transformers
+register_transformers()
+```
+
+Then load as usual (without `trust_remote_code`).
+
+## Inference Examples
+
+### Video + Audio
+
+```python
+inputs = processor(
+    text="Describe this video and its audio: <video>",
+    videos=video_frames,      # list/np/torch frames
+    audio=audio_waveform,     # raw waveform array
+    return_tensors="pt",
+)
+generated = model.generate(**inputs, max_new_tokens=128)
+print(processor.batch_decode(generated, skip_special_tokens=True)[0])
+```
+
+### Image Only
+
+```python
+inputs = processor(
+    text="What is in this image? <image>",
+    images=image,
+    return_tensors="pt",
+)
+generated = model.generate(**inputs, max_new_tokens=64)
+```
+
+### Audio Only
+
+```python
+inputs = processor(
+    text="Transcribe and summarize this audio: <audio>",
+    audio=audio_waveform,
+    return_tensors="pt",
+)
+generated = model.generate(**inputs, max_new_tokens=128)
+```
+
+## Placeholder Rules
+
+You may use `<image>`, `<video>`, `<audio>` placeholders in the prompt. The processor expands them into
+`<|vision_start|><|*_pad|>...<|vision_end|>` sequences based on the actual input sizes.
+
+If you already use `<|image_pad|>`, `<|video_pad|>`, or `<|audio_pad|>`, you can place a **single** token
+per input; the processor will expand it to the correct length.
+
+## Audio Notes
+
+- Pass raw waveform arrays (not file paths).
+- Default sampling rate: **16 kHz**.
+- Audio is chunked into 30-second windows; each window corresponds to 60 audio tokens.
+- For video + audio, the processor interleaves audio tokens per video timestep.
+
+## Files Added/Updated
+
+- `qwenvl/model/processing_video_salmonn2_plus.py`
+- `qwenvl/model/configuration_qwen2_5_vl.py`
+- `qwenvl/model/modeling_qwen2_5_vl.py`
+- `qwenvl/model/__init__.py`
+- `video_SALMONN2_plus/README.md` (Auto* usage snippet)
+- `video_SALMONN2_plus/README_transformers.md` (this file)

--- a/video_SALMONN2_plus/README_transformers.md
+++ b/video_SALMONN2_plus/README_transformers.md
@@ -78,14 +78,17 @@ You may use `<image>`, `<video>`, `<audio>` placeholders in the prompt. The proc
 `<|vision_start|><|*_pad|>...<|vision_end|>` sequences based on the actual input sizes.
 
 If you already use `<|image_pad|>`, `<|video_pad|>`, or `<|audio_pad|>`, you can place a **single** token
-per input; the processor will expand it to the correct length.
+per input; the processor will expand it to the correct length. A `<audio>` or `<|audio_pad|>` placeholder
+is treated as an **explicit audio block**, so audio will not be interleaved into video tokens in that case.
+For video+audio interleaving, use `<video>` only and provide the audio waveform separately.
 
 ## Audio Notes
 
 - Pass raw waveform arrays (not file paths).
+- Channel-first `(channels, samples)` and channel-last `(samples, channels)` arrays are supported and downmixed to mono.
 - Default sampling rate: **16 kHz**.
 - Audio is chunked into 30-second windows; each window corresponds to 60 audio tokens.
-- For video + audio, the processor interleaves audio tokens per video timestep.
+- For video + audio, the processor interleaves audio tokens per video timestep **only if no explicit `<audio>` or `<|audio_pad|>` placeholder is present**.
 
 ## Files Added/Updated
 

--- a/video_SALMONN2_plus/qwenvl/__init__.py
+++ b/video_SALMONN2_plus/qwenvl/__init__.py
@@ -1,0 +1,1 @@
+# Namespace for video-SALMONN2+ modules.

--- a/video_SALMONN2_plus/qwenvl/model/__init__.py
+++ b/video_SALMONN2_plus/qwenvl/model/__init__.py
@@ -1,0 +1,27 @@
+from .configuration_qwen2_5_vl import BertConfig, Qwen2_5_VLConfig, Qwen2_5_VLVisionConfig, WhisperConfig
+from .modeling_qwen2_5_vl import VideoSALMONN2PlusForConditionalGeneration, video_SALMONN2_plus
+from .processing_video_salmonn2_plus import VideoSALMONN2PlusProcessor
+
+
+def register_transformers():
+    """
+    Optional: register the VideoSALMONN2Plus classes with Transformers Auto* APIs.
+    Call this if you want to use AutoModel/AutoProcessor without trust_remote_code.
+    """
+    from transformers import AutoConfig, AutoModelForCausalLM, AutoProcessor
+
+    AutoConfig.register("qwen2_5_vl", Qwen2_5_VLConfig, exist_ok=True)
+    AutoModelForCausalLM.register(Qwen2_5_VLConfig, VideoSALMONN2PlusForConditionalGeneration, exist_ok=True)
+    AutoProcessor.register(Qwen2_5_VLConfig, VideoSALMONN2PlusProcessor, exist_ok=True)
+
+
+__all__ = [
+    "BertConfig",
+    "Qwen2_5_VLConfig",
+    "Qwen2_5_VLVisionConfig",
+    "WhisperConfig",
+    "video_SALMONN2_plus",
+    "VideoSALMONN2PlusForConditionalGeneration",
+    "VideoSALMONN2PlusProcessor",
+    "register_transformers",
+]

--- a/video_SALMONN2_plus/qwenvl/model/configuration_qwen2_5_vl.py
+++ b/video_SALMONN2_plus/qwenvl/model/configuration_qwen2_5_vl.py
@@ -377,6 +377,16 @@ class Qwen2_5_VLConfig(PretrainedConfig):
         audio_config=None,
         rope_scaling=None,
         audio_token_id=151665,
+        image_token_id=151655,
+        video_token_id=151656,
+        vision_start_token_id=151652,
+        vision_end_token_id=151653,
+        image_token="<|image_pad|>",
+        video_token="<|video_pad|>",
+        audio_token="<|audio_pad|>",
+        vision_start_token="<|vision_start|>",
+        vision_end_token="<|vision_end|>",
+        auto_map=None,
         **kwargs,
     ):
         if isinstance(vision_config, dict):
@@ -414,6 +424,15 @@ class Qwen2_5_VLConfig(PretrainedConfig):
         self.attention_dropout = attention_dropout
         self.rope_scaling = rope_scaling
         self.audio_token_id = audio_token_id
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.vision_start_token_id = vision_start_token_id
+        self.vision_end_token_id = vision_end_token_id
+        self.image_token = image_token
+        self.video_token = video_token
+        self.audio_token = audio_token
+        self.vision_start_token = vision_start_token
+        self.vision_end_token = vision_end_token
 
         # Validate the correctness of rotary position embeddings parameters
         # BC: if there is a 'type' field, move it to 'rope_type'.
@@ -428,5 +447,15 @@ class Qwen2_5_VLConfig(PretrainedConfig):
 
         super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
 
+        # Default auto_map for Transformers custom code loading.
+        if auto_map is None:
+            self.auto_map = {
+                "AutoConfig": "qwenvl.model.configuration_qwen2_5_vl.Qwen2_5_VLConfig",
+                "AutoModelForCausalLM": "qwenvl.model.modeling_qwen2_5_vl.VideoSALMONN2PlusForConditionalGeneration",
+                "AutoProcessor": "qwenvl.model.processing_video_salmonn2_plus.VideoSALMONN2PlusProcessor",
+            }
+        else:
+            self.auto_map = auto_map
 
-__all__ = ["Qwen2_5_VLConfig"]
+
+__all__ = ["Qwen2_5_VLConfig", "Qwen2_5_VLVisionConfig", "WhisperConfig", "BertConfig"]

--- a/video_SALMONN2_plus/qwenvl/model/processing_video_salmonn2_plus.py
+++ b/video_SALMONN2_plus/qwenvl/model/processing_video_salmonn2_plus.py
@@ -1,0 +1,412 @@
+# Copyright (2025) Tsinghua University, Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adopted from https://github.com/QwenLM/Qwen2.5-VL. The original license is located at 'third-party-license/qwenvl.txt'.
+
+import math
+from typing import List, Optional, Union
+
+import numpy as np
+import torch
+
+from transformers.image_processing_utils import BatchFeature
+from transformers.image_utils import ImageInput, VideoInput
+from transformers.processing_utils import AudioInput, ProcessingKwargs, ProcessorMixin, Unpack
+from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
+
+
+class VideoSALMONN2PlusProcessorKwargs(ProcessingKwargs, total=False):
+    _defaults = {
+        "text_kwargs": {
+            "padding": False,
+            "return_mm_token_type_ids": False,
+        },
+    }
+
+
+def _split_into_groups(counts, groups, second_per_grid_ts=None):
+    result = []
+    if second_per_grid_ts is None:
+        for count, g in zip(counts, groups):
+            g = int(g)
+            base = count // g
+            remainder = count % g
+            if remainder == 0:
+                group_list = [base] * g
+            else:
+                group_list = [base] * g
+                step = g / remainder
+                for i in range(1, remainder + 1):
+                    position = i * step
+                    index = math.floor(position) - 1
+                    if index >= g:
+                        index = g - 1
+                    group_list[index] += 1
+            result.append(group_list)
+    else:
+        for count, g, second in zip(counts, groups, second_per_grid_ts):
+            g = int(g)
+            frame_idx = (torch.arange(g) * second * 2).long()
+            per_grid_t = torch.diff(frame_idx)
+            group_list = per_grid_t.tolist()
+            group_list.append(count - sum(group_list))
+            result.append(group_list)
+    return result
+
+
+class VideoSALMONN2PlusProcessor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer", "feature_extractor"]
+    image_processor_class = "AutoImageProcessor"
+    feature_extractor_class = "AutoFeatureExtractor"
+    tokenizer_class = ("Qwen2Tokenizer", "Qwen2TokenizerFast")
+
+    def __init__(
+        self,
+        image_processor=None,
+        tokenizer=None,
+        feature_extractor=None,
+        chat_template=None,
+        **kwargs,
+    ):
+        self.image_token = getattr(tokenizer, "image_token", "<|image_pad|>")
+        self.video_token = getattr(tokenizer, "video_token", "<|video_pad|>")
+        self.audio_token = getattr(tokenizer, "audio_token", "<|audio_pad|>")
+        self.vision_start_token = getattr(tokenizer, "vision_start_token", "<|vision_start|>")
+        self.vision_end_token = getattr(tokenizer, "vision_end_token", "<|vision_end|>")
+
+        self.image_token_id = (
+            tokenizer.image_token_id
+            if getattr(tokenizer, "image_token_id", None)
+            else tokenizer.convert_tokens_to_ids(self.image_token)
+        )
+        self.video_token_id = (
+            tokenizer.video_token_id
+            if getattr(tokenizer, "video_token_id", None)
+            else tokenizer.convert_tokens_to_ids(self.video_token)
+        )
+        self.audio_token_id = (
+            tokenizer.audio_token_id
+            if getattr(tokenizer, "audio_token_id", None)
+            else tokenizer.convert_tokens_to_ids(self.audio_token)
+        )
+
+        super().__init__(image_processor, tokenizer, feature_extractor, chat_template=chat_template)
+
+        self.auto_map = {
+            "AutoProcessor": "qwenvl.model.processing_video_salmonn2_plus.VideoSALMONN2PlusProcessor"
+        }
+
+    def _get_num_visual_tokens(self, grid_thw, merge_size):
+        if isinstance(grid_thw, torch.Tensor):
+            num_patches = int(torch.prod(grid_thw).item())
+        else:
+            num_patches = int(np.prod(grid_thw))
+        return num_patches // (merge_size**2)
+
+    def _prepare_audio_features(self, audio: AudioInput):
+        if audio is None:
+            return None, None
+
+        if isinstance(audio, (list, tuple)):
+            audio_list = list(audio)
+        else:
+            audio_list = [audio]
+
+        audio_inputs = []
+        audio_lengths = []
+        sampling_rate = getattr(self.feature_extractor, "sampling_rate", 16000)
+        chunk_length = getattr(self.feature_extractor, "chunk_length", 30)
+        segment_samples = int(sampling_rate * chunk_length)
+
+        for audio_item in audio_list:
+            if isinstance(audio_item, str):
+                raise ValueError(
+                    "Audio file paths are not supported in this processor. "
+                    "Please provide raw audio arrays."
+                )
+            audio_array = np.array(audio_item, dtype=np.float32)
+            if audio_array.ndim > 1:
+                audio_array = np.mean(audio_array, axis=0)
+            if audio_array.shape[0] < segment_samples:
+                pad = segment_samples - audio_array.shape[0]
+                audio_array = np.pad(audio_array, (0, pad), mode="constant", constant_values=0)
+
+            segments = [
+                audio_array[i : i + segment_samples]
+                for i in range(0, audio_array.shape[0], segment_samples)
+            ]
+            segment_features = []
+            for segment in segments:
+                features = self.feature_extractor(
+                    segment,
+                    sampling_rate=sampling_rate,
+                    padding="max_length",
+                    return_attention_mask=False,
+                    return_tensors="pt",
+                )["input_features"].squeeze(0)
+                segment_features.append(features)
+            audio_inputs.append(torch.stack(segment_features, dim=0))
+            audio_lengths.append(math.ceil(audio_array.shape[0] / segment_samples) * 60)
+
+        audio_feature = torch.cat(audio_inputs, dim=0) if audio_inputs else None
+        return audio_feature, audio_lengths
+
+    def _expand_images(self, text, image_grid_thw, merge_size):
+        if image_grid_thw is None:
+            return text
+        use_image_placeholders = any("<image>" in t for t in text)
+        use_image_token_placeholders = False
+        if not use_image_placeholders:
+            total_image_tokens = sum(t.count(self.image_token) for t in text)
+            use_image_token_placeholders = total_image_tokens == len(image_grid_thw)
+        image_index = 0
+        for i in range(len(text)):
+            if "<image>" in text[i]:
+                parts = text[i].split("<image>")
+            elif use_image_token_placeholders and self.image_token in text[i]:
+                parts = text[i].split(self.image_token)
+            else:
+                continue
+            new_parts = []
+            for part in parts[:-1]:
+                new_parts.append(part)
+                num_image_tokens = self._get_num_visual_tokens(image_grid_thw[image_index], merge_size)
+                replacement = (
+                    f"{self.vision_start_token}"
+                    + (self.image_token * num_image_tokens)
+                    + f"{self.vision_end_token}"
+                )
+                new_parts.append(replacement)
+                image_index += 1
+            new_parts.append(parts[-1])
+            text[i] = "".join(new_parts)
+        return text
+
+    def _expand_audios(self, text, audio_lengths):
+        if audio_lengths is None:
+            return text
+        use_audio_placeholders = any("<audio>" in t for t in text)
+        use_audio_token_placeholders = False
+        if not use_audio_placeholders:
+            total_audio_tokens = sum(t.count(self.audio_token) for t in text)
+            use_audio_token_placeholders = total_audio_tokens == len(audio_lengths)
+        audio_index = 0
+        for i in range(len(text)):
+            if "<audio>" in text[i]:
+                parts = text[i].split("<audio>")
+            elif use_audio_token_placeholders and self.audio_token in text[i]:
+                parts = text[i].split(self.audio_token)
+            else:
+                continue
+            new_parts = []
+            for part in parts[:-1]:
+                new_parts.append(part)
+                if audio_index >= len(audio_lengths):
+                    raise ValueError("Not enough audio inputs for <audio> placeholders.")
+                replacement = (
+                    f"{self.vision_start_token}"
+                    + (self.audio_token * audio_lengths[audio_index])
+                    + f"{self.vision_end_token}"
+                )
+                new_parts.append(replacement)
+                audio_index += 1
+            new_parts.append(parts[-1])
+            text[i] = "".join(new_parts)
+        return text
+
+    def _expand_videos(
+        self,
+        text,
+        video_grid_thw,
+        merge_size,
+        audio_lengths=None,
+        second_per_grid_ts=None,
+        audio_for_video=False,
+    ):
+        if video_grid_thw is None:
+            return text
+
+        use_video_placeholders = any("<video>" in t for t in text)
+        use_video_token_placeholders = False
+        if not use_video_placeholders:
+            total_video_tokens = sum(t.count(self.video_token) for t in text)
+            use_video_token_placeholders = total_video_tokens == len(video_grid_thw)
+
+        if audio_for_video and audio_lengths is not None:
+            groups = [int(grid[0]) for grid in video_grid_thw]
+            if second_per_grid_ts is not None:
+                second_per_grid_ts = [ts[0] if isinstance(ts, (list, tuple)) else ts for ts in second_per_grid_ts]
+            per_timestep_audio_len = _split_into_groups(audio_lengths, groups, second_per_grid_ts)
+        else:
+            per_timestep_audio_len = None
+
+        video_index = 0
+        for i in range(len(text)):
+            if "<video>" in text[i]:
+                parts = text[i].split("<video>")
+            elif use_video_token_placeholders and self.video_token in text[i]:
+                parts = text[i].split(self.video_token)
+            else:
+                continue
+            new_parts = []
+            for part in parts[:-1]:
+                new_parts.append(part)
+                if video_index >= len(video_grid_thw):
+                    raise ValueError("Not enough video inputs for <video> placeholders.")
+                if audio_for_video and audio_lengths is not None:
+                    t = int(video_grid_thw[video_index][0])
+                    h = int(video_grid_thw[video_index][1])
+                    w = int(video_grid_thw[video_index][2])
+                    tokens_per_frame = (h * w) // (merge_size**2)
+                    replacement = f"{self.vision_start_token}"
+                    for step in range(t):
+                        replacement += (self.video_token * tokens_per_frame)
+                        replacement += (self.audio_token * per_timestep_audio_len[video_index][step])
+                    replacement += f"{self.vision_end_token}"
+                else:
+                    num_video_tokens = self._get_num_visual_tokens(video_grid_thw[video_index], merge_size)
+                    replacement = (
+                        f"{self.vision_start_token}"
+                        + (self.video_token * num_video_tokens)
+                        + f"{self.vision_end_token}"
+                    )
+                new_parts.append(replacement)
+                video_index += 1
+            new_parts.append(parts[-1])
+            text[i] = "".join(new_parts)
+        return text
+
+    def _check_special_mm_tokens(self, text, text_inputs, modalities):
+        for modality in modalities:
+            token_str = getattr(self, f"{modality}_token")
+            token_id = getattr(self, f"{modality}_token_id")
+            ids_count = [list(ids).count(token_id) for ids in text_inputs["input_ids"]]
+            text_count = [sample.count(token_str) for sample in text]
+            if ids_count != text_count:
+                raise ValueError(
+                    f"Mismatch in `{modality}` token count between text and `input_ids`. "
+                    f"Got ids={ids_count} and text={text_count}. "
+                    "Likely due to `truncation='max_length'`. Please disable truncation or increase `max_length`."
+                )
+
+    def __call__(
+        self,
+        images: Optional[ImageInput] = None,
+        text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
+        videos: Optional[VideoInput] = None,
+        audio: Optional[AudioInput] = None,
+        second_per_grid_ts: Optional[List] = None,
+        **kwargs: Unpack[VideoSALMONN2PlusProcessorKwargs],
+    ) -> BatchFeature:
+        if images is None and text is None and videos is None and audio is None:
+            raise ValueError(
+                "You need to provide at least one input to call VideoSALMONN2PlusProcessor."
+            )
+
+        output_kwargs = self._merge_kwargs(
+            VideoSALMONN2PlusProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
+        image_inputs = {}
+        video_inputs = {}
+        image_grid_thw = None
+        video_grid_thw = None
+        if images is not None:
+            image_inputs = self.image_processor(images=images, **output_kwargs["images_kwargs"])
+            image_grid_thw = image_inputs.get("image_grid_thw")
+
+        if videos is not None:
+            video_inputs = self.image_processor(videos=videos, **output_kwargs["videos_kwargs"])
+            video_grid_thw = video_inputs.get("video_grid_thw")
+
+        audio_feature, audio_lengths = self._prepare_audio_features(audio)
+
+        if text is not None:
+            if not isinstance(text, list):
+                text = [text]
+            text = text.copy()
+
+            merge_size = getattr(self.image_processor, "merge_size", 2)
+            text = self._expand_images(text, image_grid_thw, merge_size)
+            audio_for_video = audio_lengths is not None and videos is not None and all("<audio>" not in t for t in text)
+            if audio_for_video and video_grid_thw is not None and len(audio_lengths) != len(video_grid_thw):
+                raise ValueError("Number of audio inputs must match number of videos when audio is interleaved.")
+
+            text = self._expand_videos(
+                text,
+                video_grid_thw,
+                merge_size,
+                audio_lengths=audio_lengths,
+                second_per_grid_ts=second_per_grid_ts,
+                audio_for_video=audio_for_video,
+            )
+            text = self._expand_audios(text, audio_lengths)
+
+            return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
+            return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)
+            text_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"], return_tensors=None)
+
+            modalities = []
+            if images is not None:
+                modalities.append("image")
+            if videos is not None:
+                modalities.append("video")
+            if audio_lengths is not None:
+                modalities.append("audio")
+            if modalities:
+                self._check_special_mm_tokens(text, text_inputs, modalities=modalities)
+
+            if return_mm_token_type_ids:
+                array_ids = np.array(text_inputs["input_ids"])
+                mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
+                mm_token_type_ids[array_ids == self.image_token_id] = 1
+                mm_token_type_ids[array_ids == self.video_token_id] = 2
+                mm_token_type_ids[array_ids == self.audio_token_id] = 3
+                text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+
+        else:
+            text_inputs = {}
+            return_tensors = output_kwargs["common_kwargs"].get("return_tensors", None)
+
+        audio_inputs = {}
+        if audio_feature is not None:
+            audio_inputs["audio_feature"] = audio_feature
+            audio_inputs["audio_lengths"] = audio_lengths
+
+        if second_per_grid_ts is not None:
+            audio_inputs["second_per_grid_ts"] = second_per_grid_ts
+
+        batch = BatchFeature(
+            data={**text_inputs, **image_inputs, **video_inputs, **audio_inputs},
+            tensor_type=return_tensors,
+        )
+        for key in ("audio_lengths", "second_per_grid_ts"):
+            if key in batch and isinstance(batch[key], torch.Tensor):
+                batch[key] = batch[key].tolist()
+        return batch
+
+    def post_process_image_text_to_text(
+        self, generated_outputs, skip_special_tokens=True, clean_up_tokenization_spaces=False, **kwargs
+    ):
+        return self.tokenizer.batch_decode(
+            generated_outputs,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
+
+
+__all__ = ["VideoSALMONN2PlusProcessor", "VideoSALMONN2PlusProcessorKwargs"]


### PR DESCRIPTION
 - add Transformers Auto* compatibility via config auto_map, model alias, and a register_transformers() helper
 - introduce VideoSALMONN2PlusProcessor with image/video/audio handling and placeholder expansion
 - document Auto* usage and examples in README(s)
